### PR TITLE
 datasubscriber: pool measurement buffers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sttp/goapi
 
-go 1.18
+go 1.22
 
 require github.com/google/uuid v1.3.0
 

--- a/sttp/MeasurementReader.go
+++ b/sttp/MeasurementReader.go
@@ -39,9 +39,9 @@ func newMeasurementReader(parent *Subscriber) *MeasurementReader {
 		current: make(chan *transport.Measurement),
 	}
 
-	parent.SetNewMeasurementsReceiver(func(measurements []transport.Measurement) {
-		for i := range measurements {
-			reader.current <- &measurements[i]
+	parent.SetNewMeasurementsReceiver(func(measurements *[]transport.Measurement) {
+		for _, m := range *measurements {
+			reader.current <- &m
 		}
 	})
 

--- a/sttp/Subscriber.go
+++ b/sttp/Subscriber.go
@@ -100,6 +100,10 @@ func (sb *Subscriber) dataSubscriber() *transport.DataSubscriber {
 	return sb.ds
 }
 
+func (sb *Subscriber) PutMeasurementSlice(m []transport.Measurement) {
+	sb.ds.MeasurementPool.Put(m[:0])
+}
+
 // IsConnected determines if Subscriber is currently connected to a data publisher.
 // When Subscriber is listening for connections, this method will only return true
 // once a data publisher successfully connects to the listening socket.

--- a/sttp/Subscriber.go
+++ b/sttp/Subscriber.go
@@ -100,8 +100,9 @@ func (sb *Subscriber) dataSubscriber() *transport.DataSubscriber {
 	return sb.ds
 }
 
-func (sb *Subscriber) PutMeasurementSlice(m []transport.Measurement) {
-	sb.ds.MeasurementPool.Put(m[:0])
+func (sb *Subscriber) PutMeasurementSlice(m *[]transport.Measurement) {
+	*m = (*m)[:0]
+	sb.ds.MeasurementPool.Put(m)
 }
 
 // IsConnected determines if Subscriber is currently connected to a data publisher.
@@ -780,7 +781,7 @@ func (sb *Subscriber) SetConfigurationChangedReceiver(callback func()) {
 
 // SetNewMeasurementsReceiver defines the callback that handles reception of new measurements.
 // Assignment will take effect immediately, even while subscription is active.
-func (sb *Subscriber) SetNewMeasurementsReceiver(callback func(measurements []transport.Measurement)) {
+func (sb *Subscriber) SetNewMeasurementsReceiver(callback func(measurements *[]transport.Measurement)) {
 	ds := sb.dataSubscriber()
 	ds.BeginCallbackAssignment()
 	defer ds.EndCallbackAssignment()

--- a/sttp/transport/DataSubscriber.go
+++ b/sttp/transport/DataSubscriber.go
@@ -111,7 +111,7 @@ type DataSubscriber struct {
 	ConfigurationChangedCallback func()
 
 	// NewMeasurementsCallback is called when DataSubscriber receives a set of new measurements from the DataPublisher.
-	NewMeasurementsCallback func([]Measurement)
+	NewMeasurementsCallback func(*[]Measurement)
 
 	// NewBufferBlocksCallback is called when DataSubscriber receives a set of new buffer block measurements from the DataPublisher.
 	NewBufferBlocksCallback func([]BufferBlock)
@@ -1253,7 +1253,7 @@ func (ds *DataSubscriber) handleDataPacket(data []byte) {
 	if ds.NewMeasurementsCallback != nil {
 		// Do not use Go routine here, processing sequence may be important.
 		// Execute callback directly from socket processing thread:
-		ds.NewMeasurementsCallback(*measurements)
+		ds.NewMeasurementsCallback(measurements)
 	}
 
 	ds.EndCallbackSync()

--- a/sttp/version/Version.go
+++ b/sttp/version/Version.go
@@ -29,7 +29,7 @@ const (
 
 	// STTPVersion defines the STTP library API version used for data subscriber identification.
 	// Note: This is not the STTP protocol version, but the version of the STTP library API.
-	STTPVersion = "0.8.1"
+	STTPVersion = "0.9.0"
 
 	// STTPUpdatedOn defines when the STTP library API was last updated used for data subscriber identification.
 	STTPUpdatedOn = "2022-12-09"


### PR DESCRIPTION
We can easily process upwards of 20,000 packets per second in real-world conditions; allocating and deallocating 20,000 slices a second is silly. To that end, I've made a few changes here:

- Construct a sync.Pool on startup. Rather than pooling measurement slices (`[]Measurement`) directly, we pool _pointers_ to the slices. Slice headers are 24 bytes, and retrieving one via `pool.Get()` would still require an allocation; retrieving `*[]Measurement` instead allows us to reuse the slice headers, not just the underlying buffers.
- When we receive measurements from the data publisher, store them in a buffer grabbed from the pool instead of allocating a new buffer.
- Expose an API that a subscriber may use to return buffers back to the pool. Subscriber cooperation is required, as the subscriber may take measurements we hand them and store them for later processing; we do not currently require them not to.
- Change the MeasurementsCallback API to yield pointers to buffers rather than the buffers themselves, to facilitate pooling the slice headers.
- Update the MeasurementReader type to use the new API
- Bump the library's API version from 0.8.1 to 0.9.0 to account for the API breakage. This would be a major version bump, but the library is pre-1.0, so a minor version bump is sufficient.