### PR TITLE
CompactMeasurements: add publishing API, optimize

### DIFF
--- a/sttp/transport/CompactMeasurement.go
+++ b/sttp/transport/CompactMeasurement.go
@@ -94,6 +94,36 @@ func (compactFlags compactStateFlagsEnum) mapToFullFlags() StateFlagsEnum {
 	return fullFlags
 }
 
+func (fullFlags StateFlagsEnum) mapToCompactFlags() compactStateFlagsEnum {
+	var compactFlags compactStateFlagsEnum
+
+	if (fullFlags & dataRangeMask) > 0 {
+		compactFlags |= compactStateFlags.DataRange
+	}
+
+	if (fullFlags & dataQualityMask) > 0 {
+		compactFlags |= compactStateFlags.DataQuality
+	}
+
+	if (fullFlags & timeQualityMask) > 0 {
+		compactFlags |= compactStateFlags.TimeQuality
+	}
+
+	if (fullFlags & systemIssueMask) > 0 {
+		compactFlags |= compactStateFlags.SystemIssue
+	}
+
+	if (fullFlags & calculatedValueMask) > 0 {
+		compactFlags |= compactStateFlags.CalculatedValue
+	}
+
+	if (fullFlags & discardedValueMask) > 0 {
+		compactFlags |= compactStateFlags.DiscardedValue
+	}
+
+	return compactFlags
+}
+
 // CompactMeasurement defines a measured value, in simple compact format, for transmission or reception in STTP.
 type CompactMeasurement struct {
 	Value                    float32

--- a/sttp/transport/CompactMeasurement.go
+++ b/sttp/transport/CompactMeasurement.go
@@ -126,10 +126,10 @@ func (fullFlags StateFlagsEnum) mapToCompactFlags() compactStateFlagsEnum {
 
 // CompactMeasurement defines a measured value, in simple compact format, for transmission or reception in STTP.
 type CompactMeasurement struct {
-	Value                    float32
-	Timestamp                ticks.Ticks
-	SignalIndex              uint32
-	Flags                    compactStateFlagsEnum
+	Value       float32
+	Timestamp   ticks.Ticks
+	SignalIndex uint32
+	Flags       compactStateFlagsEnum
 }
 
 // Constructs a CompactMeasurement from the specified byte buffer; returns the measurement and the number of bytes occupied by this measurement.
@@ -183,18 +183,17 @@ func NewCompactMeasurement(includeTime, useMillisecondResolution bool, baseTimeO
 // Compute the full measurement from the compact representation
 func (cm *CompactMeasurement) Expand(signalIndexCache *SignalIndexCache) Measurement {
 	return Measurement{
-		SignalID: signalIndexCache.SignalID(int32(cm.SignalIndex)),
+		SignalID:  signalIndexCache.SignalID(int32(cm.SignalIndex)),
 		Timestamp: cm.Timestamp,
-		Value: float64(cm.Value),
-		Flags: cm.Flags.mapToFullFlags(),
+		Value:     float64(cm.Value),
+		Flags:     cm.Flags.mapToFullFlags(),
 	}
 }
 
-//// Serializes a CompactMeasurement to a byte buffer for publication to a DataSubscriber.
+// // Serializes a CompactMeasurement to a byte buffer for publication to a DataSubscriber.
 func (cm *CompactMeasurement) Marshal(b []byte) {
 	b[0] = byte(cm.Flags)
 	binary.BigEndian.PutUint32(b[1:], cm.SignalIndex)
 	binary.BigEndian.PutUint32(b[5:], math.Float32bits(float32(cm.Value)))
 	binary.BigEndian.PutUint64(b[9:], uint64(cm.Timestamp))
 }
-

--- a/sttp/transport/DataSubscriber.go
+++ b/sttp/transport/DataSubscriber.go
@@ -1353,12 +1353,10 @@ func (ds *DataSubscriber) parseCompactMeasurements(signalIndexCache *SignalIndex
 
 	useMillisecondResolution := ds.subscription.UseMillisecondResolution
 	includeTime := ds.subscription.IncludeTime
-	index := 0
 
 	for i := 0; i < len(measurements); i++ {
 		// Deserialize compact measurement format
-		compactMeasurement := NewCompactMeasurement(signalIndexCache, includeTime, useMillisecondResolution, &ds.baseTimeOffsets)
-		bytesDecoded, err := compactMeasurement.Decode(data[index:])
+		cm, n, err := NewCompactMeasurement(includeTime, useMillisecondResolution, &ds.baseTimeOffsets, data)
 
 		if err != nil {
 			ds.dispatchErrorMessage("Failed to parse compact measurements - disconnecting: " + err.Error())
@@ -1366,8 +1364,8 @@ func (ds *DataSubscriber) parseCompactMeasurements(signalIndexCache *SignalIndex
 			return
 		}
 
-		index += bytesDecoded
-		measurements[i] = compactMeasurement.Measurement
+		data = data[n:]
+		measurements[i] = cm.Expand(signalIndexCache)
 	}
 }
 

--- a/sttp/transport/SignalIndexCache.go
+++ b/sttp/transport/SignalIndexCache.go
@@ -36,13 +36,13 @@ import (
 // SignalIndexCache maps 32-bit runtime IDs to 128-bit globally unique Measurement IDs. The structure
 // additionally provides reverse lookup and an extra mapping to human-readable measurement keys.
 type SignalIndexCache struct {
-	reference      map[int32]uint32
-	signalIDList   []guid.Guid
-	sourceList     []string
-	idList         []uint64
-	signalIDCache  map[guid.Guid]int32
-	binaryLength   uint32
-	tsscDecoder    *tssc.Decoder
+	reference     map[int32]uint32
+	signalIDList  []guid.Guid
+	sourceList    []string
+	idList        []uint64
+	signalIDCache map[guid.Guid]int32
+	binaryLength  uint32
+	tsscDecoder   *tssc.Decoder
 }
 
 // NewSignalIndexCache makes a new SignalIndexCache


### PR DESCRIPTION
This makes the representation of compactmeasurements lighter, and drops exposed APIs that are only needed internally. It also implements a method for encoding CompactMeasurements into byte buffers for sending across the network. This is needed for sttpserver.